### PR TITLE
use SPACE instead of NO-BREAK SPACE

### DIFF
--- a/src/base/comm.cpp
+++ b/src/base/comm.cpp
@@ -471,19 +471,19 @@ namespace banksia {
 		GetSystemInfo(&sysinfo);
 		return sysinfo.dwNumberOfProcessors;
 #elif MACOS
-        int nm[2];
-        size_t len = 4;
-        uint32_t count;
-     
-        nm[0] = CTL_HW; nm[1] = HW_AVAILCPU;
-        sysctl(nm, 2, &count, &len, NULL, 0);
-     
-        if(count < 1) {
-            nm[1] = HW_NCPU;
-            sysctl(nm, 2, &count, &len, NULL, 0);
-            if(count < 1) { count = 1; }
-            }
-        return count;
+        int nm[2];
+        size_t len = 4;
+        uint32_t count;
+     
+        nm[0] = CTL_HW; nm[1] = HW_AVAILCPU;
+        sysctl(nm, 2, &count, &len, NULL, 0);
+     
+        if(count < 1) {
+            nm[1] = HW_NCPU;
+            sysctl(nm, 2, &count, &len, NULL, 0);
+            if(count < 1) { count = 1; }
+            }
+        return count;
 #else
         return int(sysconf(_SC_NPROCESSORS_ONLN));
 #endif


### PR DESCRIPTION
For some reason NO-BREAK SPACE was used in these lines. This prevented compiling with cmake under Linux.