### PR TITLE
fix 3-fold repetition detection

### DIFF
--- a/src/chess/chess.cpp
+++ b/src/chess/chess.cpp
@@ -1057,7 +1057,7 @@ Result ChessBoard::rule()
         return result;
     }
     
-    if (quietCnt >= 3 * 4) {
+    if (quietCnt >= 2 * 4) {
         auto cnt = 0;
         auto i = int(histList.size()), k = i - quietCnt;
         for(i -= 2; i >= 0 && i >= k; i -= 2) {
@@ -1066,7 +1066,7 @@ Result ChessBoard::rule()
                 cnt++;
             }
         }
-        if (cnt >= 3) {
+        if (cnt >= 2) {
             result.result = ResultType::draw;
             result.reason = ReasonType::repetition;
             return result;


### PR DESCRIPTION
The original version failed to detect 3-fold repetitions after the third repetition. I took the correct values from your [Banksia for iOS](https://github.com/nguyenpham/banksiagui-ios/blob/04f9179ab2b95c734e2ed734295f28d0cfe1ffd4/BanksiaIOS/chess/ChessBoard.swift#L1739) project.
I checked the patch with 50 Halogen games, there was no illegal move by Halogen and all positions detected as 3-fold repetition seem to be correct.

Fixes #15 